### PR TITLE
Solved the problem `go mod` fails

### DIFF
--- a/glogrus.go
+++ b/glogrus.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"time"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"goji.io"
 	"golang.org/x/net/context"
 )


### PR DESCRIPTION
On the current version `go mod` fails like that:
```
$ go mod tidy
go: finding github.com/goji/glogrus2 latest
go: github.com/Sirupsen/logrus@v1.4.2: parsing go.mod: unexpected module path "github.com/sirupsen/logrus"
go: error loading module requirements
```